### PR TITLE
Adjust the use of the word "so-called" in sentences 

### DIFF
--- a/Documentation/ContentMapping/Index.rst
+++ b/Documentation/ContentMapping/Index.rst
@@ -7,8 +7,8 @@
 Content Mapping
 ===============
 
-Having a perfect visual appearance of a website is pointless, if content
- entered into the backend is not shown in the frontend. In the last step, we
+Having a perfect visual appearance of a website is pointless, if the content
+entered into the backend is not visible in the frontend. In the last step, we
 map some of the backend columns, which hold content elements such as text,
 images, etc. to areas in the frontend. This can be achieved easily by using
 custom TypoScript.

--- a/Documentation/ContentMapping/Index.rst
+++ b/Documentation/ContentMapping/Index.rst
@@ -7,8 +7,8 @@
 Content Mapping
 ===============
 
-Having a perfect visual appearance of a website is pointless, if the content
-editors enter in the backend is not shown at the frontend. In the last step, we
+Having a perfect visual appearance of a website is pointless, if content
+ entered into the backend is not shown in the frontend. In the last step, we
 map some of the backend columns, which hold content elements such as text,
 images, etc. to areas in the frontend. This can be achieved easily by using
 custom TypoScript.

--- a/Documentation/ExtensionInstallation/Index.rst
+++ b/Documentation/ExtensionInstallation/Index.rst
@@ -15,7 +15,7 @@ that TYPO3 has been installed the *traditional way*, by extracting the source
 package into the web directory **without** using PHP *composer*.
 
 By using this method, extensions (e.g. the site package extension) can be
-installed using the Extension Manager, which is a so-called *module* of the
+installed using the Extension Manager, which is a *module* found in the
 backend of TYPO3. Before we can install the site package extension, we have to
 transfer the files from our local machine to the TYPO3 server (if all files and
 directories have been created on the local machine though).
@@ -124,7 +124,7 @@ TypoScript Template
 Now we will add a TypoScript template to the site and include the TypoScript
 configuration we have created during the development of our site package. Do
 not be confused about the terminology "template". In this context, we are
-referring to a so-called TypoScript template, not a HTML/CSS/JS template.
+referring to TypoScript templates, not HTML/CSS/JS templates.
 
 Go to **WEB → Template** and select the page named "example.com". Then, click
 button "Create template for a new site" and change the dropdown box at the top

--- a/Documentation/FluidTemplates/Index.rst
+++ b/Documentation/FluidTemplates/Index.rst
@@ -20,7 +20,7 @@ repository at GitHub <https://github.com/TYPO3Fluid/Fluid>`__ for example.
 Quick Introduction to Fluid
 ===========================
 
-Like many other templating engines, Fluid reads so-called *template files*,
+Like many other templating engines, Fluid reads *template files*,
 processes them and replaces certain variables and specific tags with dynamic
 content. The result is a fully working website with a clean and valid HTML
 output. Dynamic elements are automatically updated as required. Navigation
@@ -28,7 +28,7 @@ menus are a typical example for this type of content. A menu exists on all
 pages across the entire website. Whenever pages are added, deleted or renamed,
 the menu items change.
 
-Fluid takes modern templating a step further. By using so-called *ViewHelpers*,
+Fluid takes modern templating a step further. By using *ViewHelpers*,
 developers can implement complex functionality and therefore extend the
 original functionality of Fluid to their heart's content. ViewHelpers are built
 in the programming language PHP. Having said that, website integrators or
@@ -314,7 +314,7 @@ following single line::
 
 Congratulations -- you just applied your first ViewHelper! HTML tags starting
 with :html:`<f:...>` are typically core ViewHelpers in Fluid. The tag
-:html:`<f:render>` is the so-called Render-ViewHelper, which (as the name suggests)
+:html:`<f:render>` is the Render-ViewHelper, which (as the name suggests)
 renders the content of a section or partial. In our case it is the latter,
 because of the :html:`partial="..."` argument. Note: do not append :file:`.html` here.
 HTML is the default format and as a convention, the ViewHelper automatically

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -68,9 +68,9 @@ not be stored in the userspace by all means.
 Security
 --------
 Files in :file:`fileadmin/` are typically meant to be publicly accessible per
-convention. To avoid a so-called information disclosure vulnerability (see the
+convention. To avoid disclosing sensitive system information (see the
 :ref:`TYPO3 Security Guide <t3security:start>` for further details),
-configuration files should not be exposed to the public.
+configuration files should not be stored in :file:`fileadmin/`.
 
 Deployment
 ----------

--- a/Documentation/MainMenuCreation/Index.rst
+++ b/Documentation/MainMenuCreation/Index.rst
@@ -99,7 +99,7 @@ main menu to the Fluid layout file, which is located under
    <f:render section="Main" />
 
 The changes are inside the :html:`<ul> ... </ul>` tags. The new code extends the
-list by a so-called "For-ViewHelper", which builds a loop and iterates variable
+list by using a "For-ViewHelper", which builds a loop and iterates variable
 `mainnavigation` as single items named :ts:`mainnavigationItem`. Each item
 represents one link to a page in the menu. The attributes we are using are:
 
@@ -112,7 +112,7 @@ represents one link to a page in the menu. The attributes we are using are:
 * :ts:`mainnavigationItem.title`: the page or link title
 
 The construct :html:`{f:if(condition: mainnavigationItem.active, then: 'active')}`
-is a special case. This is a so-called *inline notation*, that outputs the word
+is a special case. This is called an *inline notation*, that outputs the word
 `active`, if variable :ts:`mainnavigationItem.active` is set. In this example,
 the inline notation is used to output :html:`active` as the CSS class name.
 

--- a/Documentation/Preface/Index.rst
+++ b/Documentation/Preface/Index.rst
@@ -24,7 +24,7 @@ Target Audience
 
 This tutorial is written for TYPO3 integrators and developers. 
 It requires a basic understanding of HTML, CSS and JavaScript.
-Readers should have some exposure to TYPO3 and it's administrative interface (the
+Readers should have some exposure to TYPO3 and its administrative interface (the
 *backend*) prior to following this documentation. This tutorial does not require any
 software programming experience.
 

--- a/Documentation/Preface/Index.rst
+++ b/Documentation/Preface/Index.rst
@@ -13,23 +13,21 @@ Preface
 About this Document
 ===================
 
-This tutorial describes the steps required to turn a basic web design template
-(HTML, CSS, JavaScript files, etc.) into a fully working, mobile-responsive
-website in TYPO3 by building a so-called *TYPO3 extension*. Build upon an
-empty, clean TYPO3 instance, this tutorial can be understood as a "walk-
-through" for beginners to develop the visual appearance of a site in TYPO3.
-
+This tutorial details the steps required to turn a set of front end
+templates (HTML, CSS, JavaScript files, etc.) into a standalone
+*Site Package extension*.
 
 .. _target-audience:
 
 Target Audience
 ===============
 
-This tutorial predominately aims to support TYPO3 integrators and web
-developers. It requires some basic knowledge in HTML, CSS and JavaScript.
-Readers should have worked with TYPO3 and the administration interface (the
-*backend* of TYPO3) before. However, this tutorial does not require any
+This tutorial is written for TYPO3 integrators and developers. 
+It requires a basic understanding of HTML, CSS and JavaScript.
+Readers should have some exposure to TYPO3 and it's administrative interface (the
+*backend*) prior to following this documentation. This tutorial does not require any
 software programming experience.
+
 
 
 .. _credits:


### PR DESCRIPTION
This commit removes the use of the word "so-called" and contains ajustments to the effected sentances. The word so-called is being used to introduce new names and concepts, this is the incorrect use of the word. The [Cambridge Dictonary](https://dictionary.cambridge.org/dictionary/english/so-called) features two examples of the word being used and its correct use. This commit also features minor ammendments to some introductary paragraphs.

[-]  Remove the word "so-called" where required
[+] Ammend the introduction paragraph in /Preface/