### PR TITLE
use existing field for layout selection

### DIFF
--- a/Documentation/TypoScriptConfiguration/Index.rst
+++ b/Documentation/TypoScriptConfiguration/Index.rst
@@ -122,7 +122,8 @@ First, extend :ts:`// Part 1: Fluid template section` by the following lines::
       templateName = TEXT
       templateName.stdWrap.cObject = CASE
       templateName.stdWrap.cObject {
-         key.data = pagelayout
+         key.data = levelfield:-1, backend_layout_next_level, slide
+         key.override.field = backend_layout
 
          pagets__site_package_default = TEXT
          pagets__site_package_default.value = Default


### PR DESCRIPTION
there is no field `pages.pagelayout`,
the fields `backand_layout` and `backend_layout_next_level` use the already available backend layouts like the key values `pagets__*` suggest
for the field `pages.layout` an appropriate selection needs to be defined