### PR TITLE
Remove unused ts configuration from example code

### DIFF
--- a/Documentation/TypoScriptConfiguration/Index.rst
+++ b/Documentation/TypoScriptConfiguration/Index.rst
@@ -229,12 +229,7 @@ configuration options can be found in the :ref:`TypoScript Reference
       pageTitleFirst = 1
       prefixLocalAnchors = all
       removeDefaultJS = 0
-      renderCharset = utf-8
       sendCacheHeaders = 1
-      uniqueLinkVars = 1
-
-      // Disable image upscaling
-      noScaleUp = 1
 
       // Compression and concatenation of CSS and JS Files
       compressCss = 0


### PR DESCRIPTION
These properties were removed from core and serve no purpose anymore.