### PR TITLE
[TASK] Remove TYPO3_REQUESTTYPE and TYPO3_MODE

### DIFF
--- a/Documentation/ExtensionConfiguration/Index.rst
+++ b/Documentation/ExtensionConfiguration/Index.rst
@@ -83,7 +83,7 @@ stored in directory :file:`Configuration/TCA/Overrides/`. The content of this fi
 should look like the following code::
 
    <?php
-   defined('TYPO3_MODE') || die();
+   defined('TYPO3') or die();
 
    call_user_func(function()
    {


### PR DESCRIPTION
See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html
See https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1082
