### PR TITLE
Folder for language files is in singular

### DIFF
--- a/Documentation/FluidTemplates/Index.rst
+++ b/Documentation/FluidTemplates/Index.rst
@@ -66,7 +66,7 @@ listed below.
    site_package
    └── Resources
        ├── Private
-       │   ├── Languages
+       │   ├── Language
        │   ├── Layouts
        │   │   └── Page
        │   ├── Partials
@@ -134,7 +134,7 @@ directory :file:`Page/`.
 
 Language
 ~~~~~~~~
-The directory :file:`Languages/` may contain :file:`.xlf` files that are used for
+The directory :file:`Language/` may contain :file:`.xlf` files that are used for
 the localization of labels and text strings (frontend as well as backend) by
 TYPO3. This topic is not strictly related to the Fluid template engine and is
 documented in section


### PR DESCRIPTION
Somehow, the folder for language files (`Resources/Private/Language/`) is named in singular while most other folders are named plural only.