### PR TITLE
[TASK] Fix rendering warnings

### DIFF
--- a/Documentation/ExtensionConfiguration/Index.rst
+++ b/Documentation/ExtensionConfiguration/Index.rst
@@ -54,7 +54,7 @@ A detailed description of all configuration options can be found in
 Extension icon
 ==============
 
-Every extension can feature an icon using an SVG, PNG or GIF file. 
+Every extension can feature an icon using an SVG, PNG or GIF file.
 The image should be stored in :file:`Resources/Public/Icons/`.
 
 It is recommended that you use an SVG file called :file:`Extension.svg`.
@@ -72,7 +72,7 @@ should look like the following code:
 .. include:: /CodeSnippets/ExtensionConfiguration/TcaOverrideSysTemplate.rst.txt
 
 
-.. _directory-structure:
+.. _ec-directory-structure:
 
 Directory and file structure
 ============================

--- a/Documentation/FluidTemplates/Index.rst
+++ b/Documentation/FluidTemplates/Index.rst
@@ -45,7 +45,7 @@ available ViewHelpers and how to apply them can be found in the `Fluid ViewHelpe
 <https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/Index.html>`__.
 
 
-.. _directory-structure:
+.. _ft-directory-structure:
 
 Directory Structure
 ===================

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -69,7 +69,7 @@ Security
 --------
 Files in :file:`fileadmin/` are typically meant to be publicly accessible per
 convention. To avoid disclosing sensitive system information (see the
-:ref:`TYPO3 Security Guide <t3security:start>` for further details),
+:ref:`TYPO3 Security Guide <t3coreapi:security>` for further details),
 configuration files should not be stored in :file:`fileadmin/`.
 
 Deployment

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -50,7 +50,6 @@ h2document      = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us
 
 t3coreapi       = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
 t3install       = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
-t3security      = https://docs.typo3.org/m/typo3/guide-security/main/en-us/
 t3start         = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
 t3ts45          = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
 t3tsref         = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/


### PR DESCRIPTION
- remove duplicate label "directory-structure"
- update outdated label "t3security:start"

See #79 for details.