### PR TITLE
[TASK] Fix rendering warnings

### DIFF
--- a/Documentation/ExtensionConfiguration/Index.rst
+++ b/Documentation/ExtensionConfiguration/Index.rst
@@ -103,7 +103,7 @@ should look like the following code::
    });
 
 
-.. _directory-structure:
+.. _ec-directory-structure:
 
 Directory and File Structure
 ============================

--- a/Documentation/FluidTemplates/Index.rst
+++ b/Documentation/FluidTemplates/Index.rst
@@ -7,7 +7,7 @@
 Fluid Templates
 ===============
 
-Before we describe how the static files discussed in the previous section 
+Before we describe how the static files discussed in the previous section
 :ref:`design-template` can be converted into Fluid templates, we should understand
 what *Fluid* is and what the main ideas behind this powerful rendering engine
 are. It is important to point out that the following section is just a quick
@@ -47,7 +47,7 @@ TYPO3 <https://fluidtypo3.org/viewhelpers/>`__ and at the `TYPO3 Wiki
 not maintained by the TYPO3 Documentation Team.
 
 
-.. _directory-structure:
+.. _ft-directory-structure:
 
 Directory Structure
 ===================
@@ -140,7 +140,7 @@ The directory :file:`Languages/` may contain :file:`.xlf` files that are used fo
 the localization of labels and text strings (frontend as well as backend) by
 TYPO3. This topic is not strictly related to the Fluid template engine and is
 documented in section
-:ref:`Internationalization and Localization <t3coreapi:internationalization-and-localization>`.
+:ref:`Internationalization and Localization <t3coreapi:internationalization>`.
 
 
 .. _implement-templates-files:
@@ -233,9 +233,9 @@ As described before, a typical static :file:`index.html` file contains a :html:`
 and a :html:`<body>` section, but we only need to focus on the :html:`<body>`. Open
 file :file:`site_package/Resources/Private/Templates/Page/Default.html` in your
 favorite text editor and remove all lines before the starting :html:`<body>` tag
-and after the closing :html:`</body>` tag. Then, remove these two lines, too. As a 
-result, your :file:`Default.html` may now be empty. In that case, you can use the 
-following example based on the Bootstrap Jumbotron. If using your own layout template, 
+and after the closing :html:`</body>` tag. Then, remove these two lines, too. As a
+result, your :file:`Default.html` may now be empty. In that case, you can use the
+following example based on the Bootstrap Jumbotron. If using your own layout template,
 your :file:`Default.html` now contains only the HTML code inside the body.
 
 So, let's assume it contains something like the following HTML code::

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -69,7 +69,7 @@ Security
 --------
 Files in :file:`fileadmin/` are typically meant to be publicly accessible per
 convention. To avoid disclosing sensitive system information (see the
-:ref:`TYPO3 Security Guide <t3security:start>` for further details),
+:ref:`TYPO3 Security Guide <t3coreapi:security>` for further details),
 configuration files should not be stored in :file:`fileadmin/`.
 
 Deployment

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -46,7 +46,7 @@ use_opensearch       =
 # Writing documentation
 # t3wd = https://docs.typo3.org/typo3cms/HowToDocument/
 
-h2document      = https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/
+h2document      = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
 
 t3coreapi       = https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/
 t3install       = https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -48,12 +48,11 @@ use_opensearch       =
 
 h2document      = https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/
 
-t3coreapi       = https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/
-t3install       = https://docs.typo3.org/m/typo3/guide-installation/master/en-us/
-t3security      = https://docs.typo3.org/m/typo3/guide-security/master/en-us/
-t3start         = https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/
-t3ts45          = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/master/en-us/
-t3tsref         = https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/
+t3coreapi       = https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/
+t3install       = https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/
+t3start         = https://docs.typo3.org/m/typo3/tutorial-getting-started/10.4/en-us/
+t3ts45          = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/10.4/en-us/
+t3tsref         = https://docs.typo3.org/m/typo3/reference-typoscript/10.4/en-us/
 
 
 

--- a/Documentation/Summary/Index.rst
+++ b/Documentation/Summary/Index.rst
@@ -159,7 +159,7 @@ Tutorial - Sitepackages - Part 1 of 3
 
 `YouTube: Part 1 of 3 <https://www.youtube.com/watch?v=HtBmim7pc0o>`__
 
-.. only:: html, singlehtml
+.. only:: html or singlehtml
 
    .. youtube:: HtBmim7pc0o
 
@@ -169,7 +169,7 @@ Tutorial - Sitepackages - Part 2 of 3
 
 `YouTube: Part 2 of 3 <https://www.youtube.com/watch?v=deSMVfCSCXY>`__
 
-.. only:: html, singlehtml
+.. only:: html or singlehtml
 
    .. youtube:: deSMVfCSCXY
 
@@ -179,6 +179,6 @@ Tutorial - Sitepackages - Part 3 of 3
 
 `YouTube: Part 3 of 3 <https://www.youtube.com/watch?v=SEoWOBT0rQE>`__
 
-.. only:: html, singlehtml
+.. only:: html or singlehtml
 
    .. youtube:: SEoWOBT0rQE


### PR DESCRIPTION
- remove duplicate label "directory-structure"
- make intersphinx mappings version-aware
- fix :only: directive with multiple formats
- fix undefined label "t3coreapi:internationalization-and-localization"
- fix undefined label "t3coreapi:security"

See #79 for details.