### PR TITLE
Fix typo in section label

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,7 +1,7 @@
 .. include:: /Includes.rst.txt
 
 
-.. introduction:
+.. _introduction:
 
 ============
 Introduction


### PR DESCRIPTION
This fixes a problem of not being able to link to this section.