### PR TITLE
Add start section label on start page

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
 
+.. _start:
+
 ==========================
 TYPO3 Sitepackage Tutorial
 ==========================


### PR DESCRIPTION
This complies to the convention, that all manuals
had a start label on the start page so that you
could link to it like this:

:ref:`t3sitepackage:start`