### PR TITLE
MinimalExample: Fixed path. +Composer config ref

### DIFF
--- a/Documentation/MinimalExample/Index.rst
+++ b/Documentation/MinimalExample/Index.rst
@@ -50,9 +50,10 @@ then add the following lines in the field:
    page.1.file = EXT:site_package/Resources/Private/Templates/Minimal.html
 
 Create a file named :file:`Minimal.html` in a
-:file:`typo3conf/site_package/Resources/Private/Templates` folder.
+:file:`typo3conf/ext/site_package/Resources/Private/Templates` folder.
 
 The site package extension has to be :ref:`installed <extension-installation>`
+and requires a :ref:`minimal composer configuration <extension-configuration>` (if composer is used)
 for this to work
 
 .. code-block:: html


### PR DESCRIPTION
If you use composer, the composer config shown in "extension installation" is insufficient. You have to provide the extension key at least. Otherwise your site package extension will be missing. => Added reference to "extension configuration" which has a perfect example.

Also fixed the template file's path.