### PR TITLE
[TASK] Put default interlink shortcode

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -7,6 +7,7 @@
                edit-on-github="TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage"
                edit-on-github-branch="main"
                typo3-core-preferred="main"
+               interlink-shortcode="t3sitepackage"
                project-home="https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/"
                project-contact="https://typo3.slack.com/archives/C028JEPJL"
                project-repository="https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage"


### PR DESCRIPTION
This way the suggested interlinks when clicking on a title show the correct interlink