### PR TITLE
[TASK] Remove 13.3 Warnings

### DIFF
--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,6 +1,1 @@
 ﻿..  You can put central messages to display on all pages here
-
-..  warning::
-    This tutorial assumes you are using at least TYPO3 v13.3. If you want to
-    use the current LTS (long time support) version 12.4 of TYPO3, switch
-    to the :ref:`Site package tutorial for TYPO3 v12.4 <t3sitepackage-12:start>`.


### PR DESCRIPTION
TYPO3 13.4 is LTS now

Releases: main, 13.4