### PR TITLE
[TASK] Unify Site Package Tutorial title

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -13,7 +13,7 @@
                project-repository="https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage"
                project-issues="https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage/issues"
     />
-    <project title="Sitepackage Tutorial"
+    <project title="Site Package Tutorial"
              version="main (development)"
              release="main (development)"
              copyright="since 2017 by the TYPO3 contributors"


### PR DESCRIPTION
Site package are two words. We currently have it in one word in the manual title but in two words title on the startpage etc

Releases: main, 13.4, 12.4