### PR TITLE
[FEATURE] Rename top-level module "web" to "content"

### DIFF
--- a/Documentation/ContentMapping/AddContent.rst
+++ b/Documentation/ContentMapping/AddContent.rst
@@ -12,7 +12,7 @@ The pages generated in step
 already contain some example content.
 
 You can add additonal content in the backend. Go to
-:guilabel:`Web > Page` and select any of the pages you created before,
+:guilabel:`Content > Page` and select any of the pages you created before,
 (for example "Page 2"). Click the :guilabel:`+ Create new content` button
 in the column labelled "*Main*" and choose the "Regular Text
 Element" content element.

--- a/Documentation/CreatePages/Index.rst
+++ b/Documentation/CreatePages/Index.rst
@@ -39,7 +39,7 @@ reloading the backend.
 ..  figure:: PageModule.png
     :alt: Screenshot of the backend module "Page" with the loaded example data
 
-    The page tree in the module :guilabel:`Web > Page` now contains a few example pages.
+    The page tree in the module :guilabel:`Content > Page` now contains a few example pages.
 
 ..  note::
     This only works for site packages of type "Site Package Tutorial". The ones


### PR DESCRIPTION
References: TYPO3-Documentation/Changelog-To-Doc#1373
Releases: main