### PR TITLE
Use correct order for setting up a new extension

### DIFF
--- a/Documentation/ContentBlocks/Index.rst
+++ b/Documentation/ContentBlocks/Index.rst
@@ -46,12 +46,12 @@ If not first install the extension :composer:`friendsoftypo3/content-blocks`:
 
     ddev composer req friendsoftypo3/content-blocks
 
-Set up the extension and delete all caches:
+First, flush all caches. Then, set up the extension.
 
 ..  code-block:: bash
 
-    ddev typo3 extension:setup
     ddev typo3 cache:flush
+    ddev typo3 extension:setup
 
 ..  _content-blocks-jumbotron:
 


### PR DESCRIPTION
The command extension:setup uses (TCA) cache to create new tables and fields. Therefore, the cache needs to be cleared first.